### PR TITLE
Switch submodules to use https instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,8 +15,8 @@
 	url = https://github.com/foundry-rs/forge-std
 [submodule "sgx-prover"]
 	path = sgx-prover
-	url = git@github.com:automata-network/sgx-prover.git
+	url = https://github.com/automata-network/sgx-prover
 	branch = avs
 [submodule "linea-sgx-prover"]
 	path = linea-sgx-prover
-	url = git@github.com:automata-network/linea-sgx-prover.git
+	url = https://github.com/automata-network/linea-sgx-prover


### PR DESCRIPTION
This pull requests modifies git modules to use HTTPS instead of SSH. Since these repositories are public it makes CI systems happy whenever they do not need to use SSH for cloning the repositories.